### PR TITLE
Add Ubuntu 20.04 build and push with GitHub Actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: docker build . -f Dockerfile -t $IMAGE_NAME:$(date +%s) -t $IMAGE_NAME:latest
+      run: docker build . -f Dockerfile -t $IMAGE_NAME:20.04 -t $IMAGE_NAME:latest
 
     - if: github.ref == 'refs/heads/master'
       name: Login to Docker Hub

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,3 +18,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build the Docker image
       run: docker build . -f Dockerfile -t $IMAGE_NAME:$(date +%s) -t $IMAGE_NAME:latest
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,20 @@
+name: Docker Hub Upload
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # github.repository is <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . -f Dockerfile -t $IMAGE_NAME:$(date +%s) -t $IMAGE_NAME:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,8 @@ jobs:
     - name: Build the Docker image
       run: docker build . -f Dockerfile -t $IMAGE_NAME:$(date +%s) -t $IMAGE_NAME:latest
 
-    - name: Login to Docker Hub
+    - if: github.ref == 'refs/heads/master'
+      name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,3 +25,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - if: github.ref == 'refs/heads/master'
+      name: Push image to Docker Hub
+      run: docker push --all-tags $IMAGE_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update\
  && apt-get install -y --no-install-recommends openssh-server sudo python python-apt\
  && apt-get clean
 RUN mkdir /var/run/sshd\
- && sed -i 's|^PermitRootLogin\s+.*|PermitRootLogin yes|' /etc/ssh/sshd_config\
+ && sed -i 's|^#\?PermitRootLogin\s\+.*|PermitRootLogin yes|' /etc/ssh/sshd_config\
  && sed -i 's|session\s*required\s*pam_loginuid.so|session optional pam_loginuid.so|g' /etc/pam.d/sshd
 RUN echo 'root:root' | chpasswd\
  && useradd -m ubuntu\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 MAINTAINER Akihiro Uchida <uchida@turbare.net>
 RUN apt-get update\
  && apt-get install -y --no-install-recommends openssh-server sudo python python-apt\

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # docker-ubuntu-sshd
 
 [![License](https://img.shields.io/github/license/uchida/docker-ubuntu-sshd.svg?maxAge=2592000)](https://tldrlegal.com/license/creative-commons-cc0-1.0-universal)
-[![MicroBadger](https://images.microbadger.com/badges/image/auchida/ubuntu-sshd.svg)](http://microbadger.com/images/auchida/ubuntu-sshd)
 
 sshd enabled ubuntu docker image
 
@@ -9,7 +8,8 @@ Docker image is available as [auchida/ubuntu-sshd](https://hub.docker.com/r/auch
 
 ## Image tags
 
-- `16.04`, `xenial`, `latest`
+- `20.04`, `latest`
+- `16.04`, `xenial`
 - `14.04`, `trusty`
 
 ## Usage


### PR DESCRIPTION
This requires setting up `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in repository secrets. It can even be set to regenerate images automatically every month. Right now it is limited to 20.04.